### PR TITLE
Fix incorrect number encoder

### DIFF
--- a/src/unifier.ml
+++ b/src/unifier.ml
@@ -477,7 +477,7 @@ let rec convert_arg_to_json map_loc name var_type =
     )
   | Ntr_named "Float" ->
     Pexp_apply (
-      {pexp_desc = Pexp_ident { txt = Longident.parse "Js.Json.float"; loc = name_loc};
+      {pexp_desc = Pexp_ident { txt = Longident.parse "Js.Json.number"; loc = name_loc};
        pexp_loc = name_loc; pexp_attributes = []},
       [
         (Nolabel, {
@@ -488,7 +488,7 @@ let rec convert_arg_to_json map_loc name var_type =
     )
   | Ntr_named "Int" ->
     Pexp_apply (
-      {pexp_desc = Pexp_ident { txt = Longident.parse "Js.Json.float"; loc = name_loc};
+      {pexp_desc = Pexp_ident { txt = Longident.parse "Js.Json.number"; loc = name_loc};
        pexp_loc = name_loc; pexp_attributes = []},
       [
         (Nolabel, {

--- a/src/unifier.ml
+++ b/src/unifier.ml
@@ -110,13 +110,13 @@ let rec unify_type map_loc span ty schema (selection_set: selection list spannin
       (Pexp_apply (
           make_expression (Pexp_ident { txt = Longident.parse "Array.map"; loc = loc }),
           [(Nolabel, make_expression (
-                Pexp_fun (
-                   Nolabel,
-                   None,
-                   make_pattern (Ppat_var { txt = "value"; loc = loc }),
-                   make_expression (unify_type map_loc span t schema selection_set)
-                 );
-               ));
+               Pexp_fun (
+                 Nolabel,
+                 None,
+                 make_pattern (Ppat_var { txt = "value"; loc = loc }),
+                 make_expression (unify_type map_loc span t schema selection_set)
+               );
+             ));
            (Nolabel, make_identifier "value")]
         ))
   | Ntr_named n -> match lookup_type schema n with
@@ -128,8 +128,8 @@ let rec unify_type map_loc span ty schema (selection_set: selection list spannin
     | Some Scalar { sm_name = "Int" } ->
       make_match_fun "Js.Json.decodeNumber" (make_error_raiser loc)
         (Pexp_apply (
-          make_identifier "int_of_float",
-          [(Nolabel, make_identifier "value")]))
+            make_identifier "int_of_float",
+            [(Nolabel, make_identifier "value")]))
     | Some Scalar { sm_name = "Float" } ->
       make_match_fun "Js.Json.decodeNumber" (make_error_raiser loc)
         (Pexp_ident {txt=Longident.Lident "value"; loc = loc})
@@ -137,7 +137,7 @@ let rec unify_type map_loc span ty schema (selection_set: selection list spannin
       make_match_fun "Js.Json.decodeBoolean" (make_error_raiser loc)
         (Pexp_ident {txt=Longident.Lident "value"; loc = loc})
     | Some Scalar _ -> 
-        (Pexp_ident {txt=Longident.Lident "value"; loc = loc})
+      (Pexp_ident {txt=Longident.Lident "value"; loc = loc})
     | Some ((Object o) as ty) ->
       unify_selection_set map_loc span schema ty selection_set
     | Some Enum { em_name; em_values } ->

--- a/src/unifier.ml
+++ b/src/unifier.ml
@@ -474,7 +474,7 @@ let rec convert_arg_to_json map_loc name var_type =
       [
         (Nolabel, {
             pexp_desc = Pexp_apply (
-                {pexp_desc = Pexp_ident { txt = Longident.Lident "int_of_float"; loc = name_loc};
+                {pexp_desc = Pexp_ident { txt = Longident.Lident "float"; loc = name_loc};
                  pexp_loc = name_loc; pexp_attributes = []},
                 [
                   (Nolabel, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,9 +45,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bs-platform@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-1.8.2.tgz#2aba1cfc73e21feaa8902d67b5ddbec975938554"
+bs-platform@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-1.9.1.tgz#1195562f0f8b131cc758693e7c9b31d7e0022001"
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This PR introduces a fix for `Float` encoder. 

Another fix contributed by @szymonzmyslony is support for enums as input values.

I also made a little refactor in a separate commit. Feel free to reject the refactor; in this case I'll revert those commits.