### PR TITLE
Add a standalone type parser to generate convenience parsers

### DIFF
--- a/src/result_decoder.ml
+++ b/src/result_decoder.ml
@@ -75,7 +75,8 @@ let rec unify_type as_record map_loc span ty schema (selection_set: selection li
       ] [@metaloc loc]
     | Some ((Interface o) as ty) ->
       unify_selection_set as_record map_loc span schema ty selection_set
-    | Some InputObject obj -> raise_error map_loc span "Can't have fields on input objects"
+    | Some ((InputObject obj) as ty) -> 
+      unify_selection_set as_record map_loc span schema ty selection_set
     | Some Union um -> unify_union map_loc span schema um selection_set
 
 and unify_union map_loc span schema union_meta selection_set =

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -95,13 +95,25 @@ let lookup_field ty name =
   | [x] -> Some x
   | _ -> raise @@ Inconsistent_schema ("Multiple fields named " ^ name)
   in
+  let find_field_input fs = 
+  match List.find_all (fun f -> f.am_name = name) fs with
+  | [] -> None
+  | [x] -> Some {
+    fm_name = x.am_name;
+    fm_description = None;
+    fm_arguments = [];
+    fm_field_type = x.am_arg_type;
+    fm_deprecation_reason = None;
+  }
+  | _ -> raise @@ Inconsistent_schema ("Multiple fields named " ^ name)
+  in
   match ty with
   | Object { om_fields } -> find_field om_fields
   | Interface { im_fields } -> find_field im_fields
   | Scalar { sm_name } -> raise @@ Invalid_type ("Type " ^ sm_name ^ " doesn't have any fields")
   | Enum { em_name } -> raise @@ Invalid_type ("Type " ^ em_name ^ " doesn't have any fields")
   | Union { um_name } -> raise @@ Invalid_type ("Type " ^ um_name ^ " doesn't have any fields")
-  | InputObject { iom_name } -> raise @@ Invalid_type ("Type " ^ iom_name ^ " doesn't have any fields")
+  | InputObject { iom_input_fields } -> find_field_input iom_input_fields
 
 let type_name ty = match ty with
   | Scalar { sm_name } -> sm_name

--- a/src/standalone_type_decoder.ml
+++ b/src/standalone_type_decoder.ml
@@ -8,55 +8,63 @@ let rec complete_selection_set map_loc span schema typ selection_set_set =
     to_native_type_ref typ in
   let name = unwrapped_type_name_of_native_type_ref native_type_ref in
   let schema_typ = Schema.lookup_type schema name in
+  let generate fields field_name arg_type = 
+    let open Ast in
+    List.map (fun field -> 
+      if StringSet.mem name selection_set_set then 
+        None
+      else
+        Some (Field {
+          span = span;
+          item = {
+            fd_alias = None;
+            fd_name = {
+              span = span;
+              item = field_name field
+            };
+            fd_arguments = None;
+            fd_directives = [];
+            fd_selection_set = 
+              complete_selection_set 
+                map_loc 
+                span 
+                schema 
+                (arg_type field)
+                (StringSet.add name selection_set_set);
+          }
+        })
+    ) fields
+    |> List.fold_left (fun t ->
+      function
+      | Some x -> x::t
+      | None -> t
+    ) [] in
   match schema_typ with
   | None -> Generator_utils.raise_error map_loc span ("Could not find type " ^ name)
-  | Some Interface _ -> 
-      Generator_utils.raise_error 
-        map_loc 
-        span 
-        ("Creating standalone parsers for interfaces is currently impossible")
-  | Some InputObject _ -> 
-      Generator_utils.raise_error 
-        map_loc 
-        span 
-        ("Creating standalone parsers for input objects is currently impossible")
   | Some Union _ -> 
       Generator_utils.raise_error 
         map_loc 
         span 
         ("Creating standalone parsers for unions is currently impossible")
-  | Some Object { om_fields } ->
+  | Some InputObject { iom_input_fields } -> 
     let open Ast in
     Some {
-      span = span;
-      item = List.map (fun field -> 
-        if StringSet.mem name selection_set_set then 
-          None
-        else
-          Some (Field {
-            span = span;
-            item = {
-              fd_alias = None;
-              fd_name = {
-                span = span;
-                item = field.fm_name
-              };
-              fd_arguments = None;
-              fd_directives = [];
-              fd_selection_set = 
-                complete_selection_set 
-                  map_loc 
-                  span 
-                  schema 
-                  field.fm_field_type 
-                  (StringSet.add name selection_set_set);
-            }
-          })
-      ) om_fields 
-      |> List.fold_left (fun t -> function
-        | Some x -> x::t
-        | None -> t
-      ) []
+      span;
+      item = 
+        generate 
+          iom_input_fields 
+          (fun { am_name } -> am_name) 
+          (fun { am_arg_type } -> am_arg_type)
+    }
+  | Some Interface { im_fields = fields }
+  | Some Object { om_fields = fields } ->
+    Some {
+      span;
+      item = 
+        generate 
+          fields
+          (fun { fm_name } -> fm_name) 
+          (fun { fm_field_type } -> fm_field_type)
     }
   | _ -> None
   

--- a/src/standalone_type_decoder.ml
+++ b/src/standalone_type_decoder.ml
@@ -1,0 +1,75 @@
+module StringSet = Set.Make(String)
+
+let rec complete_selection_set map_loc span schema typ selection_set_set =
+  let open Type_utils in
+  let open Source_pos in
+  let open Schema in
+  let native_type_ref = 
+    to_native_type_ref typ in
+  let name = unwrapped_type_name_of_native_type_ref native_type_ref in
+  let schema_typ = Schema.lookup_type schema name in
+  match schema_typ with
+  | None -> Generator_utils.raise_error map_loc span ("Could not find type " ^ name)
+  | Some Interface _ -> 
+      Generator_utils.raise_error 
+        map_loc 
+        span 
+        ("Creating standalone parsers for interfaces is currently impossible")
+  | Some InputObject _ -> 
+      Generator_utils.raise_error 
+        map_loc 
+        span 
+        ("Creating standalone parsers for input objects is currently impossible")
+  | Some Union _ -> 
+      Generator_utils.raise_error 
+        map_loc 
+        span 
+        ("Creating standalone parsers for unions is currently impossible")
+  | Some Object { om_fields } ->
+    let open Ast in
+    Some {
+      span = span;
+      item = List.map (fun field -> 
+        if StringSet.mem name selection_set_set then 
+          None
+        else
+          Some (Field {
+            span = span;
+            item = {
+              fd_alias = None;
+              fd_name = {
+                span = span;
+                item = field.fm_name
+              };
+              fd_arguments = None;
+              fd_directives = [];
+              fd_selection_set = 
+                complete_selection_set 
+                  map_loc 
+                  span 
+                  schema 
+                  field.fm_field_type 
+                  (StringSet.add name selection_set_set);
+            }
+          })
+      ) om_fields 
+      |> List.fold_left (fun t -> function
+        | Some x -> x::t
+        | None -> t
+      ) []
+    }
+  | _ -> None
+  
+
+let parser_for_type typ schema map_loc =
+  let open Type_utils in
+  let open Source_pos in
+  let open Schema in
+  let schema_typ = (to_schema_type_ref typ.item) in
+  Result_decoder.unify_type 
+  false
+  map_loc
+  typ.span
+  (to_native_type_ref schema_typ)
+  schema
+  (complete_selection_set map_loc typ.span schema schema_typ StringSet.empty) 

--- a/tests/schema.gql
+++ b/tests/schema.gql
@@ -27,6 +27,7 @@ type MutationWithErrorResult {
 
 type SampleResult {
     stringField: String!
+    nested: SampleResult
 }
 
 type SampleError {

--- a/tests/types/typeParser.re
+++ b/tests/types/typeParser.re
@@ -1,3 +1,5 @@
 module NullableParser = [%graphql.parsetype "[SampleResult]"];
 
 module NonnullParser = [%graphql.parsetype "[SampleResult!]!"];
+
+module ScalarInput = [%graphql.parsetype "VariousScalarsInput!"];

--- a/tests/types/typeParser.re
+++ b/tests/types/typeParser.re
@@ -1,0 +1,3 @@
+module NullableParser = [%graphql.parsetype "[SampleResult]"];
+
+module NonnullParser = [%graphql.parsetype "[SampleResult!]!"];

--- a/tests/types/typeParser.rei
+++ b/tests/types/typeParser.rei
@@ -15,3 +15,21 @@ module NonnullParser: {
     Js.Json.t =>
     array (Js.t {. stringField : string, nested : option (Js.t {.})});
 };
+
+module ScalarInput: {
+  exception Graphql_error;
+  let parse:
+    Js.Json.t =>
+      Js.t {. 
+    nullableString: option(string),
+    string: string,
+    nullableInt: option(int),
+    int: int,
+    nullableFloat: option(float),
+    float: float,
+    nullableBoolean: option(Js.boolean),
+    boolean: Js.boolean,
+    nullableID: option(string),
+    id: string
+    };
+};

--- a/tests/types/typeParser.rei
+++ b/tests/types/typeParser.rei
@@ -1,0 +1,17 @@
+module NullableParser: {
+  exception Graphql_error;
+  let parse:
+    Js.Json.t =>
+    option (
+      array (
+        option (Js.t {. stringField : string, nested : option (Js.t {.})})
+      )
+    );
+};
+
+module NonnullParser: {
+  exception Graphql_error;
+  let parse:
+    Js.Json.t =>
+    array (Js.t {. stringField : string, nested : option (Js.t {.})});
+};


### PR DESCRIPTION
This PR adds a standalone parser useful in situations when you get json of particular type from some place and want to parse it.

It currently doesn't work with recursive objects and unions.
  