### PR TITLE
Provide headers with sendIntrospectionQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "postinstall": "if [ ! -e ./ppx ]; then ln -fs \"$(opam config var graphql_ppx:bin)/graphql_ppx.native\" ./ppx; fi"
   },
   "dependencies": {
-    "request": "^2.82.0"
+    "request": "^2.82.0",
+    "yargs": "^11.0.0"
   }
 }

--- a/sendIntrospectionQuery.js
+++ b/sendIntrospectionQuery.js
@@ -1,8 +1,32 @@
 #!/usr/bin/env node
+var argv = require("yargs")
+  .usage('Usage: $0 <url>  [--header "key:value"]')
+  .command("url", "URL of the GraphQL endpoint", { alias: "url" })
+  .required(1, "URL is required")
+  .option("H", {
+    alias: "headers",
+    describe: "Additional Headers to send with introspection request",
+    type: "array",
+    coerce: arg => {
+      let additionalHeaders = {};
+      for (const header of arg) {
+        const separator = header.indexOf(":");
+        const name = header.substring(0, separator).trim();
+        const value = header.substring(separator + 1).trim();
+        if (!(name && value)) {
+          throw new Error('Headers should be specified as "Name: Value"');
+        }
+        additionalHeaders[name] = value;
+      }
+      return additionalHeaders;
+    }
+  })
+  .help("?")
+  .alias("?", "help")
+  .example("$0 https://example.com/graphql", "Get GraphQL Schema").argv;
 
-var request = require('request');
-var fs = require('fs');
-
+var request = require("request");
+var fs = require("fs");
 var introspectionQuery = `
 query IntrospectionQuery {
     __schema {
@@ -93,26 +117,24 @@ query IntrospectionQuery {
     }
   }`;
 
-if (process.argv.length !== 3) {
-    console.error(`Usage: ${process.argv[1]} <API_URL>`);
+const requestOptions = {
+  json: true,
+  body: { query: introspectionQuery },
+  headers: { "user-agent": "node.js", ...argv.headers }
+};
+
+request.post(argv._[0], requestOptions, function(error, response, body) {
+  if (error) {
+    console.error("Could not send introspection query: ", error);
     process.exit(1);
-}
+  }
 
-request.post(
-    process.argv[2],
-    { method: 'POST', json: true, body: { query: introspectionQuery } },
-    function (error, response, body) {
-        if (error) {
-            console.error('Could not send introspection query: ', error);
-            process.exit(1);
-        }
+  if (response.statusCode !== 200) {
+    console.error("Non-ok status code from API: ", response.statusCode, response.statusMessage);
+    process.exit(1);
+  }
 
-        if (response.statusCode !== 200) {
-            console.error('Non-ok status code from API: ', response.statusCode, response.statusMessage);
-            process.exit(1);
-        }
+  var result = JSON.stringify(body, null, 2);
 
-        var result = JSON.stringify(body, null, 2);
-
-        fs.writeFileSync('graphql_schema.json', result, { encoding: 'utf-8' });
-    });
+  fs.writeFileSync("graphql_schema.json", result, { encoding: "utf-8" });
+});

--- a/sendIntrospectionQuery.js
+++ b/sendIntrospectionQuery.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 var argv = require("yargs")
-  .usage('Usage: $0 <url>  [--header "key:value"]')
+  .usage('Usage: $0 <url>  [--headers "key:value"]')
   .command("url", "URL of the GraphQL endpoint", { alias: "url" })
   .required(1, "URL is required")
   .option("H", {
@@ -23,7 +23,8 @@ var argv = require("yargs")
   })
   .help("?")
   .alias("?", "help")
-  .example("$0 https://example.com/graphql", "Get GraphQL Schema").argv;
+  .example("$0 https://example.com/graphql", "Get GraphQL Schema")
+  .example(`$0 https://example.com/graphql --headers "Authorisation: <token>"`, "Get GraphQL Schema with Authorisation header").argv;
 
 var request = require("request");
 var fs = require("fs");

--- a/sendIntrospectionQuery.js
+++ b/sendIntrospectionQuery.js
@@ -5,7 +5,7 @@ var argv = require("yargs")
   .required(1, "URL is required")
   .option("H", {
     alias: "headers",
-    describe: "Additional Headers to send with introspection request",
+    describe: "Additional Headers to send with introspection query",
     type: "array",
     coerce: arg => {
       let additionalHeaders = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,6 +3120,12 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@^10.0.3:
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.1.tgz#5fe1ea306985a099b33492001fa19a1e61efe285"
@@ -3136,6 +3142,23 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
When using `sendIntrospectionQuery`, a naked request is made.

[Apollo-Codegen's](https://github.com/apollographql/apollo-codegen#introspect-schema) version of this tool allows your to specify headers. This is a super useful when trying to grab the schema of GraphQL services that may live on the web and require authorisation - e.g. github's GraphQL endpoint.

This update allows you to pass multiple headers to `sendIntrospectionQuery` with the -H or ---headers flag. 

It also adds a bit of guidance and help to the program, making it a bit easier on the user.

```bash
❯ node sendIntrospectionQuery.js --help
Usage: sendIntrospectionQuery.js <url>  [--headers "key:value"]

Commands:
  sendIntrospectionQuery.js url  URL of the GraphQL endpoint

Options:
  --version      Show version number                                   [boolean]
  -H, --headers  Additional Headers to send with introspection query     [array]
  -?, --help     Show help                                             [boolean]

Examples:
  sendIntrospectionQuery.js                 Get GraphQL Schema
  https://example.com/graphql
  sendIntrospectionQuery.js                 Get GraphQL Schema with
  https://example.com/graphql --headers     Authorisation header
  "Authorisation: <token>"
```