### PR TITLE
Add subscription support

### DIFF
--- a/src/ast_serializer_apollo.ml
+++ b/src/ast_serializer_apollo.ml
@@ -154,7 +154,7 @@ let ser_definition = function
       ("operation", Js.Json.string([%e match item.o_type with
         | Query -> [%expr "query"]
         | Mutation -> [%expr "mutation"]
-        | Subscription -> [%expr "subscrition"]
+        | Subscription -> [%expr "subscription"]
         ]));
       ("variableDefinitions", [%e ser_variable_definitions item.o_variable_definitions]);
       ("directives", [%e ser_directives item.o_directives]);

--- a/src/ast_serializer_apollo.ml
+++ b/src/ast_serializer_apollo.ml
@@ -151,7 +151,11 @@ let ser_definition = function
   | Operation { item } -> [%expr Js.Json.object_(Js.Dict.fromArray([|
       ("kind", Js.Json.string("OperationDefinition"));
       ("name", [%e ser_optional ser_name item.o_name]);
-      ("operation", Js.Json.string([%e match item.o_type with | Query -> [%expr "query"] | Mutation -> [%expr "mutation"]]));
+      ("operation", Js.Json.string([%e match item.o_type with
+        | Query -> [%expr "query"]
+        | Mutation -> [%expr "mutation"]
+        | Subscription -> [%expr "subscrition"]
+        ]));
       ("variableDefinitions", [%e ser_variable_definitions item.o_variable_definitions]);
       ("directives", [%e ser_directives item.o_directives]);
       ("selectionSet", [%e ser_selection_set item.o_selection_set]);

--- a/src/graphql_ast.ml
+++ b/src/graphql_ast.ml
@@ -55,7 +55,7 @@ and selection =
   | FragmentSpread of fragment_spread spanning
   | InlineFragment of inline_fragment spanning
 
-type operation_type = Query | Mutation
+type operation_type = Query | Mutation | Subscription
 
 type operation = {
   o_type: operation_type;

--- a/src/graphql_parser_document.ml
+++ b/src/graphql_parser_document.ml
@@ -198,6 +198,7 @@ let parse_operation_type parser = match next parser with
   | Error e -> Error e
   | Ok ({ item = Graphql_lexer.Name "query" } as span) -> Ok (replace span Query)
   | Ok ({ item = Graphql_lexer.Name "mutation"} as span) -> Ok (replace span Mutation)
+  | Ok ({ item = Graphql_lexer.Name "subscription"} as span) -> Ok (replace span Subscription)
   | Ok span -> Error (map (fun t -> Unexpected_token t) span)
 
 let parse_operation_definition parser = Result_ext.(
@@ -261,8 +262,9 @@ let parse_fragment_definition parser = Result_ext.(
 let parse_definition parser = Result_ext.(
     match peek parser with
     | { item = Graphql_lexer.Curly_open }
-    | {item = Graphql_lexer.Name "query" }
-    | { item = Graphql_lexer.Name "mutation"} ->
+    | { item = Graphql_lexer.Name "query" }
+    | { item = Graphql_lexer.Name "mutation" } 
+    | { item = Graphql_lexer.Name "subscription" }->
       parse_operation_definition parser |> map (fun def -> Operation def)
 
     | { item = Graphql_lexer.Name "fragment" } ->

--- a/src/graphql_printer.ml
+++ b/src/graphql_printer.ml
@@ -103,8 +103,11 @@ let print_variable_definitions defs =
   "(" ^ (List.map print_variable_definition defs |> String.concat ", ") ^ ")"
 
 let print_operation schema op =
-  let ty_name = match op.o_type with | Query -> schema.meta.sm_query_type | Mutation -> Option.unsafe_unwrap schema.meta.sm_mutation_type in
-  (match op.o_type with | Query -> "query " | Mutation -> "mutation ") ^
+  let ty_name = match op.o_type with
+    | Query -> schema.meta.sm_query_type
+    | Mutation -> Option.unsafe_unwrap schema.meta.sm_mutation_type
+    | Subscription -> Option.unsafe_unwrap schema.meta.sm_subscription_type in
+  (match op.o_type with | Query -> "query " | Mutation -> "mutation " | Subscription -> "subscription ") ^
   (match op.o_name with | Some { item } -> item | None -> "") ^
   (match op.o_variable_definitions with | Some { item } -> print_variable_definitions item | None -> "") ^
   (print_directives op.o_directives) ^

--- a/src/result_decoder.ml
+++ b/src/result_decoder.ml
@@ -156,11 +156,19 @@ let unify_operation error_marker config = function
   | { item = { o_type = Query; o_selection_set; o_variable_definitions }; span }
     -> unify_selection_set error_marker false config span (query_type config.schema) (Some o_selection_set)
   | { item = { o_type = Mutation; o_selection_set; o_variable_definitions }; span } 
-    -> match mutation_type config.schema with
-    | Some mutation_type -> 
-      unify_selection_set error_marker false config span mutation_type (Some o_selection_set)
-    | None ->
-      make_error error_marker config.map_loc span "This schema does not contain any mutations"
+    -> begin match mutation_type config.schema with
+        | Some mutation_type -> 
+          unify_selection_set error_marker false config span mutation_type (Some o_selection_set)
+        | None ->
+          make_error error_marker config.map_loc span "This schema does not contain any mutations"
+      end
+  | { item = { o_type = Subscription; o_selection_set; o_variable_definitions }; span }
+    -> begin match subscription_type config.schema with
+        | Some subscription_type ->
+          unify_selection_set error_marker false config span subscription_type (Some o_selection_set)
+        | None->
+          make_error error_marker config.map_loc span "This schema does not contain any subscriptions"
+      end
 
 let rec unify_document_schema config document =
   let error_marker = { Generator_utils.has_error = false } in

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -100,6 +100,9 @@ let query_type s = Hashtbl.find s.type_map s.meta.sm_query_type
 let mutation_type s = match s.meta.sm_mutation_type with
   | Some n -> Some (Hashtbl.find s.type_map n)
   | None -> None 
+let subscription_type s = match s.meta.sm_subscription_type with
+  | Some n -> Some (Hashtbl.find s.type_map n)
+  | None -> None
 
 exception Invalid_type of string
 exception Inconsistent_schema of string

--- a/src/traversal_utils.ml
+++ b/src/traversal_utils.ml
@@ -327,6 +327,7 @@ module Visitor(V: VisitorSig) = struct
     let def_type = Schema.NonNull(Schema.Named(match def with
         | Operation { item = { o_type = Query } } -> Schema.query_type ctx.schema |> Schema.type_name
         | Operation { item = { o_type = Mutation } } -> Schema.mutation_type ctx.schema |> Option.unsafe_unwrap |> Schema.type_name
+        | Operation { item = { o_type = Subscription } } -> Schema.subscription_type ctx.schema |> Option.unsafe_unwrap |> Schema.type_name
         | Fragment { item = { fg_type_condition = { item } } } -> item))
     in
     let ctx = Context.push_type ctx (Some def_type) in

--- a/tests/schema.gql
+++ b/tests/schema.gql
@@ -1,6 +1,7 @@
 schema {
     query: Query
     mutation: Mutation
+    subscription: Subscription
 }
 
 type Query {
@@ -19,6 +20,10 @@ type Query {
 
 type Mutation {
     mutationWithError: MutationWithErrorResult!
+}
+
+type Subscription {
+    simpleSubscription: DogOrHuman!
 }
 
 type MutationWithErrorResult {

--- a/tests/types/subscription.re
+++ b/tests/types/subscription.re
@@ -1,0 +1,13 @@
+module MyQuery = [%graphql
+  {| subscription {
+    simpleSubscription {
+      ...on Dog {
+        name
+      }
+      ...on Human {
+        name
+      }
+    }
+  }
+|}
+];

--- a/tests/types/subscription.rei
+++ b/tests/types/subscription.rei
@@ -1,0 +1,12 @@
+module MyQuery: {
+  type t = Js.t({
+    .
+    simpleSubscription: [
+      | `Dog(Js.t({ . name: string }))
+      | `Human(Js.t({ . name: string }))
+    ],
+  });
+
+  let make: unit => Js.t({ . parse: Js.Json.t => t, query: string, variables: Js.Json.t });
+  let makeWithVariables: Js.t({.}) => Js.t({ . parse: Js.Json.t => t, query: string, variables: Js.Json.t });
+};


### PR DESCRIPTION
This _should_ add subscription support: the parser, schema, and unifier now knows about that operation type. Fixes #33.

I don't have a good setup to test subscription support, but I assume the responses look just like the responses from queries and mutations. @Gregoirevda, could you maybe verify that this is the case for reason-apollo?