### PR TITLE
Add -apollo-mode which adds __typename on every GraphQL Object in query

### DIFF
--- a/src/base/graphql_printer.ml
+++ b/src/base/graphql_printer.ml
@@ -70,7 +70,11 @@ let rec print_type ty = match ty with
 let rec print_selection_set schema ty ss = match ss with
   | [] -> [||]
   | l ->
-    let add_typename = match ty with | Interface _ | Union _ -> true | _ -> false in
+    let add_typename = match ty with
+    | Interface _ | Union _ -> true 
+    | Object _ -> Ppx_config.apollo_mode ()
+    | _ -> false
+    in
     Array.concat [
       [|
         String "{\n";

--- a/src/base/ppx_config.ml
+++ b/src/base/ppx_config.ml
@@ -6,6 +6,7 @@ type config = {
   verbose_logging: bool;
   output_mode: output_mode;
   verbose_error_handling: bool;
+  apollo_mode: bool;
   root_directory: string;
   schema_file: string;
   raise_error_with_loc: 'a. Source_pos.ast_location -> string -> 'a
@@ -20,6 +21,9 @@ let verbose_logging () =
 
 let output_mode () =
   (!config_ref |> Option.unsafe_unwrap).output_mode
+
+let apollo_mode () =
+  (!config_ref |> Option.unsafe_unwrap).apollo_mode
 
 let verbose_error_handling () =
   (!config_ref |> Option.unsafe_unwrap).verbose_error_handling

--- a/src/bucklescript/graphql_ppx.ml
+++ b/src/bucklescript/graphql_ppx.ml
@@ -114,6 +114,9 @@ let mapper argv =
               | _ -> true
               | exception Not_found -> true
             end);
+      apollo_mode = (match List.find ((=) "-apollo-mode") argv with
+          | _ -> true
+          | exception Not_found -> false);
       root_directory = Sys.getcwd ();
       schema_file = (match List.find (is_prefixed "-schema=") argv with
           | arg -> drop_prefix "-schema=" arg

--- a/tests_bucklescript/__tests__/apolloMode.re
+++ b/tests_bucklescript/__tests__/apolloMode.re
@@ -1,0 +1,35 @@
+
+module MyQuery = [%graphql {|
+  {
+    first: nestedObject {
+      inner {
+        inner {
+          field
+        }
+      }
+    }
+
+    second: nestedObject {
+      inner {
+        inner {
+          f1: field
+          f2: field
+        }
+      }
+    }
+  }
+|}];
+
+Jest.(describe("Apollo mode", () => {
+  open Expect;
+  open! Expect.Operators;
+
+  test("Adds __typename to objects", () => {
+    let typenameRegex = [%bs.re {|/__typename/g|}];
+    Js.log(MyQuery.query)
+    MyQuery.query
+    |> Js.String.match(typenameRegex)
+    |> Belt.Option.map(_, Array.length)
+    |> expect == Some(7);
+  });
+}));

--- a/tests_bucklescript/__tests__/apolloMode.rei
+++ b/tests_bucklescript/__tests__/apolloMode.rei
@@ -1,0 +1,12 @@
+module MyQuery: {
+  type t = Js.t({
+    .
+    first: Js.t({. inner: option(Js.t({. inner : option(Js.t({. field : string})) })) }),
+    second: Js.t({. inner : option(Js.t({. inner : option(Js.t({. f1: string, f2: string})) })) }),
+  });
+
+  let make: unit => Js.t({ . parse: Js.Json.t => t, query: string, variables: Js.Json.t });
+  let makeWithVariables: Js.t({.}) => Js.t({ . parse: Js.Json.t => t, query: string, variables: Js.Json.t });
+
+  let query: string;
+};

--- a/tests_bucklescript/bsconfig.json
+++ b/tests_bucklescript/bsconfig.json
@@ -4,7 +4,7 @@
         "__tests__"
     ],
     "ppx-flags": [
-        "../graphql_ppx.exe"
+        "../graphql_ppx.exe -apollo-mode"
     ],
     "bs-dependencies": [
         "@glennsl/bs-jest"


### PR DESCRIPTION
"Apollo mode" adds `__typename` on every GraphQL Object. It allows using `reason-apollo` cache more efficiently. 
I'm not sure how properly test that but I've assumed that counting `__typename` occurences in nested query would do the job.

Should fix: #39 

/cc @Gregoirevda