### PR TITLE
Fix send-introspection-query command for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ directory:
 ```sh
 yarn send-introspection-query http://my-api.example.com/api
 # or, if you use npm
-npm run send-introspection-query http://my-api.example.com/api
+npx send-introspection-query http://my-api.example.com/api
 ```
 
 


### PR DESCRIPTION
`npm run send-introspection-query ` does not work.

```
$ npm run send-introspection-query http://localhost:3000/graphql
npm ERR! missing script: send-introspection-query

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/lallinuo/.npm/_logs/2019-04-22T07_09_52_599Z-debug.log```
```

it should be `npx send-introspection-query http://localhost:3000/graphql` instead.